### PR TITLE
Revert "fix for Package.getActivationCommands is deprecated"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "rails-rspec",
   "main": "./lib/rails-rspec",
-  "version": "0.3.2",
+  "version": "0.3.1",
   "description": "Toggle spec and tested file in rails project",
-  "activationCommands": [
+  "activationEvents": [
     "rails-rspec:toggle-spec-file"
   ],
   "repository": "https://github.com/wangyuhere/atom-rails-rspec",


### PR DESCRIPTION
Reverts wangyuhere/atom-rails-rspec#8

activationEvents should be an object instead of array.
